### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Set the connection string for your DB library to
 `postgres://<username>:<password>@localhost:<local port>/<database-name>`
 
 Start the proxy before your app tries to connect to the database by e.g. adding 
-`bin/run_cloud_sql_proxy` to the `.profile` in the root of your project.
+`bin/run_cloud_sql_proxy` to the `.procfile` in the root of your project.


### PR DESCRIPTION
Not familiar with the .profile. I think its a simple typo and it was intended to say .procfile as this is the file Heroku uses when spinning up a dyno.